### PR TITLE
Increase limit of the request payload

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,7 +24,7 @@ impl Api {
             .route("/metrics", axum::routing::get(routes::metrics))
             .route("/healthz", axum::routing::get(routes::healthz))
             .route("/solve", axum::routing::post(routes::solve))
-            .layer(DefaultBodyLimit::max(5 * 1024 * 1024))
+            .layer(DefaultBodyLimit::max(50 * 1024 * 1024))
             .layer(
                 tower::ServiceBuilder::new().layer(tower_http::trace::TraceLayer::new_for_http()),
             )


### PR DESCRIPTION
Logs show many 413 status codes.  The payload that cow solver is sending us something like almost 6MB, and I think the our cow-solver rejects it. We likely will need to make a code change.

Note that