### PR TITLE
fix: bump github actions to node24 runtimes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,8 +13,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
           labels: |
             org.opencontainers.image.licenses=GPL-3.0-or-later
       - name: Solvers image build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.binary

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -35,7 +35,7 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: 0
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - run: cargo build --tests
@@ -45,6 +45,6 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: npm install @apidevtools/swagger-cli
       - run: node_modules/.bin/swagger-cli validate openapi.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0 # Fetch all history for all branches and tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: "Create release"
         if: env.CHANGES_DETECTED == 'true'
-        uses: "actions/github-script@v6"
+        uses: "actions/github-script@v9"
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |

--- a/.github/workflows/update-cow-dependencies.yaml
+++ b/.github/workflows/update-cow-dependencies.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
GitHub removes Node ≤20 action runtimes from runners on 2026-09-16 (forced Node 24 default since 2026-06-16) — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions updated to their Node 24 releases:

- `actions/checkout` v2/v3 → v6
- `docker/login-action` v2 → v4