### PR TITLE
fix: bump github actions to node24 runtimes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Solvers image metadata
         id: meta_solvers
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           labels: |


### PR DESCRIPTION
GitHub removes Node ≤20 action runtimes from runners on 2026-09-16 (forced Node 24 default since 2026-06-16) — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Version-agnostic sweep of remaining node≤20 action pins to their Node 24 releases:

- `docker/metadata-action` v4 → v6