### PR TITLE
fix: migrate archived actions-rs to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,9 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
       - run: |


### PR DESCRIPTION
GitHub removes Node ≤20 action runtimes from runners on 2026-09-16 — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). `actions-rs/*` is archived and stuck on node12, so it's replaced:

- `actions-rs/toolchain@v1` (node12, archived) → `dtolnay/rust-toolchain`

References
- https://linear.app/0xproject/issue/PLA-1666/upgrade-all-node-20-github-actions-org-wide-before-runner-removal